### PR TITLE
release workflow depends on tags to sync new

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,9 @@ on:
     types: [completed]
 
 jobs:
-  changes:
+  tag:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
-
-    outputs:
-      gosrc: ${{ steps.filter.outputs.gosrc }}
 
     steps:
       - name: checkout
@@ -21,20 +18,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: filter-src
-        id: filter
-        uses: dorny/paths-filter@v2
+      - name: tag
+        uses: mathieudutour/github-tag-action@v5.5
         with:
-          filters: |
-            gosrc:
-              - '**/*.go'
-              - 'go.mod'
-              - 'go.sum'
+          default_bump: false
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   release:
-    needs: changes
+    needs: tag
 
-    if: ${{ needs.changes.outputs.gosrc == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -47,11 +39,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.16.x
-
-      - name: tag
-        uses: mathieudutour/github-tag-action@v5.5
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: goreleaser
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
not sure what the right pattern for this is but it seems that the tag action isn't manipulating the local repo but the GH API, so we need to sync the local checkout with GH after tag.