### PR TITLE
support fully qualified refs

### DIFF
--- a/internal/git/clone.go
+++ b/internal/git/clone.go
@@ -27,7 +27,7 @@ func New() *Git {
 
 func (g *Git) Clone(url string, ref string, dir string) error {
 	// is the ref a fully qualified ref such as 'refs/tags/<ref>'?
-	if strings.Contains(ref, "/") {
+	if strings.HasPrefix(ref, "refs/") {
 		opts := g.mkCloneOptions(url, plumbing.ReferenceName(ref))
 		_, err := git.PlainClone(dir, cloneBare, opts)
 		if err != nil {

--- a/internal/git/clone.go
+++ b/internal/git/clone.go
@@ -26,10 +26,23 @@ func New() *Git {
 }
 
 func (g *Git) Clone(url string, ref string, dir string) error {
+	// is the ref a fully qualified ref such as 'refs/tags/<ref>'?
+	if strings.Contains(ref, "/") {
+		opts := g.mkCloneOptions(url, plumbing.ReferenceName(ref))
+		_, err := git.PlainClone(dir, cloneBare, opts)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// attempt to to clone a branch reference such as 'refs/head/<ref>'
 	opts := g.mkCloneOptions(url, plumbing.NewBranchReferenceName(ref))
 	_, err := git.PlainClone(dir, cloneBare, opts)
 
 	// is err of type git.NoMatchingRefSpecError?
+	// attempt to to clone a tag reference such as 'refs/tags/<ref>'
 	if _, ok := err.(git.NoMatchingRefSpecError); ok {
 		opts = g.mkCloneOptions(url, plumbing.NewTagReferenceName(ref))
 		_, err = git.PlainClone(dir, cloneBare, opts)

--- a/internal/git/clone_test.go
+++ b/internal/git/clone_test.go
@@ -74,6 +74,15 @@ func TestGit_Clone(t *testing.T) {
 				dir: th.CreateTempDir(t),
 			},
 		},
+		{
+			name:        "nonexistent reference containg '/'",
+			expectedErr: errors.New("couldn't find remote ref \"refs/tags/foo/master\""),
+			args: args{
+				url: "https://github.com/terraform-aws-modules/terraform-aws-iam.git",
+				ref: "foo/master",
+				dir: th.CreateTempDir(t),
+			},
+		},
 	}
 	for _, tt := range tests {
 		// capture range variable for t.Parallel()


### PR DESCRIPTION
# description

This seeks to address issue #25.

The primary motivation for the change is in support of [github.com/mdb/terrajux-action](https://github.com/mdb/terrajux-action/).

# type of change

please `[x]` any relevant options

- [ ] bug (non-breaking change fixing an issue)
- [X] feature (non-breaking change which adds functionality)
- [ ] breaking change (fix or feature that might cause existing functionality not to work as expected)
- [ ] requires documentation update
- [ ] other (describe)

# testing

The change was tested via updated unit tests run on Mac OS, which can also be run in CI.

The change was also tested by producing a local build via `make snapshot` and executing the following:

```
./dist/terrajux_darwin_amd64/terrajux https://github.com/terraform-aws-modules/terraform-aws-iam.git refs/heads/master v3.0.0
```

...as well as:

```
./dist/terrajux_darwin_amd64/terrajux https://github.com/terraform-aws-modules/terraform-aws-iam.git refs/heads/master refs/tags/v3.0.0
```

# checklist

please `[x]` any relevant options

- [ ] [an issue](https://github.com/rhenning/terrajux/issues) has been created
- [ ] new or changed code augments or modifies test cases
- [X] `make test` completes with no errors
- [X] `go fmt` has been run
- [X] relevant documentation has been updated