### PR TITLE
improve cache behavior when using file:// scheme urls

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,10 +1,17 @@
 package cache
 
-import "os"
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+)
 
-type Initializer interface {
+type Manager interface {
 	Ensure() error
 	Clear() error
+	HasKey(key string) bool
+	GetAbsKeyPath(key string) (abspath string, err error)
 }
 
 type Cache struct {
@@ -27,4 +34,22 @@ func (c *Cache) Clear() error {
 	}
 
 	return c.Ensure()
+}
+
+func (c *Cache) HasKey(k string) bool {
+	if _, err := os.Stat(path.Join(c.Dir, k)); os.IsNotExist(err) {
+		return false
+	}
+
+	return true
+}
+
+func (c *Cache) GetAbsKeyPath(k string) (string, error) {
+	var err error
+
+	if !c.HasKey(k) {
+		err = fmt.Errorf("cache key %q not found", k)
+	}
+
+	return filepath.Join(c.Dir, k), err
 }

--- a/internal/git/clone.go
+++ b/internal/git/clone.go
@@ -3,6 +3,7 @@ package git
 import (
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"strings"
 
 	git "github.com/go-git/go-git/v5"
@@ -55,8 +56,8 @@ func URLPath(u string, ref string) (path string) {
 		return urlPathSSH(u, ref)
 	}
 
-	path = fmt.Sprintf("%s%s/%s", up.Host, up.Path, ref)
-	return path
+	path = fmt.Sprintf("%s/%s/%s/%s/%s", up.Scheme, up.Hostname(), up.Port(), up.Path, ref)
+	return filepath.Clean(path)
 }
 
 func urlPathSSH(u string, ref string) (path string) {
@@ -64,5 +65,5 @@ func urlPathSSH(u string, ref string) (path string) {
 	hostpath := ss[len(ss)-1]
 	hostpath = strings.Replace(hostpath, ":", "/", 1)
 	path = fmt.Sprintf("%s/%s", hostpath, ref)
-	return path
+	return filepath.Clean(path)
 }

--- a/internal/git/clone_test.go
+++ b/internal/git/clone_test.go
@@ -69,16 +69,52 @@ func TestURLPath(t *testing.T) {
 				ref: "main",
 			},
 
-			wantPath: "test.com/foo/bar.git/main",
+			wantPath: "https/test.com/foo/bar.git/main",
 		},
 		{
-			name: "ssh+noscheme+user",
+			name: "scplike+noscheme+user",
 			args: args{
 				url: "git@test.com:foo/bar.git",
 				ref: "v2.0.0",
 			},
 
 			wantPath: "test.com/foo/bar.git/v2.0.0",
+		},
+		{
+			name: "standard+filescheme",
+			args: args{
+				url: "file:///tmp/terrajux-test/something",
+				ref: "main",
+			},
+
+			wantPath: "file/tmp/terrajux-test/something/main",
+		},
+		{
+			name: "standard+scheme+port",
+			args: args{
+				url: "https://test.com:8443/foo/bar.git",
+				ref: "main",
+			},
+
+			wantPath: "https/test.com/8443/foo/bar.git/main",
+		},
+		{
+			name: "standard+scheme+port+dirtypath",
+			args: args{
+				url: "https://test.com:8443/foo/../bar",
+				ref: "main",
+			},
+
+			wantPath: "https/test.com/8443/bar/main",
+		},
+		{
+			name: "scplike+dirtypath",
+			args: args{
+				url: "git@test.com:foo/bar.git",
+				ref: "main",
+			},
+
+			wantPath: "test.com/foo/bar.git/main",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# description

cache behavior wasn't really designed with file:// urls or possible absolute filepaths in the cache key. because the cache implemenation is a directory on the under the hood, using a cache key of `/path/to/my/git/repository` had all sorts of fun implications. this pr is an attempt to make some improvements, but it's a WIP (see `# testing` section).

fixes #24 

please `[x]` any relevant options

- [x] bug (non-breaking change fixing an issue)
- [ ] feature (non-breaking change which adds functionality)
- [ ] breaking change (fix or feature that might cause existing functionality not to work as expected)
- [ ] requires documentation update
- [ ] other (describe)


# testing

a few rudimentary test cases have been added but they're incomplete. some of the new methods in the cache need tests and this might be the time to start working on #9 as refactoring this broke some things that are not well tested (like logic in the `app` package.)


# checklist

please `[x]` any relevant options

- [x] [an issue](https://github.com/rhenning/terrajux/issues) has been created
- [ ] new or changed code augments or modifies test cases
- [x] `make test` completes with no errors
- [x] `go fmt` has been run
- [ ] relevant documentation has been updated
